### PR TITLE
Update .gitignore to exclude figures folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Figures in examples/figures folder
+examples/figures/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Exclude the `examples/figures` folder from version control to keep the repository clean. Additionally, merge previous changes related to the main figure manager.